### PR TITLE
Use with_first_found instead of the deprecated first_available_file

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure fail2ban.conf
   copy: src={{ item }} dest="{{ fail2ban_dir_conf }}/fail2ban.conf" backup=no owner=root group=root mode=0644
-  first_available_file:
+  with_first_found:
     - "fail2ban.conf.{{ ansible_os_family }}"
     - "fail2ban.conf.default"
   notify:
@@ -20,7 +20,7 @@
 
 - name: Ensure jail.conf
   copy: src={{ item }} dest="{{ fail2ban_dir_conf }}/jail.conf" backup=no owner=root group=root mode=0644
-  first_available_file:
+  with_first_found:
     - "jail.conf.{{ ansible_os_family }}"
     - "jail.conf.default"
   notify:


### PR DESCRIPTION
I was getting and error when running this role:

```
fatal: [localhost] => One or more undefined variables: 'item' is undefined
```

Updated documentation: http://docs.ansible.com/playbooks_loops.html#finding-first-matched-files

According to @mpdehaan `first_available_file` has been deprecated and `with_first_found` is the updated way.
